### PR TITLE
Misc: Update Adapter & Packages

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -8,4 +8,4 @@ packages:
   - package: dbt-labs/spark_utils
     version: 0.3.0
   - package: dbt-labs/metrics
-    version: 1.3.0
+    version: 1.3.2


### PR DESCRIPTION
In this PR we are making a small change by updating the metrics package to the latest version.

In addition, in dbt Cloud the respective Databricks connection now uses the databricks adapter. 

I have chosen `hive_metastore` as the catalogue so everything "stays" the same.
I have seen that @amychen1776 has already created an own partner engineering workspace 
but when setting the `database` config on a source level to `samples` or `hive_metastore` we run into the following issue

`[UC_COMMAND_NOT_SUPPORTED] Creating a persistent view that references both Unity Catalog and Hive Metastore objects is not supported in Unity Catalog.`

Amy has raised this with the DBX team https://dbt-labs.slack.com/archives/C01N1PC89PZ/p1669072643556549

This does not block this PR to move forward, but was worth documenting. 