### PR TITLE
Enable Grants

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -41,6 +41,8 @@ dispatch:
 models:
   file_format: delta
   incremental_strategy: merge
+  +grants:
+    select: ['Partner Engineers']
 
   databricks_demo:
       # Applies to all files under models/example/
@@ -50,4 +52,6 @@ models:
           materialized: table
       marts:
           materialized: table
+
+on-run-start: "grant usage on schema {{target.database}}.{{target.schema}} to `Partner Engineers`"
     


### PR DESCRIPTION
In this PR we enable our grants feature for the project.

> Databricks recommends using account groups instead of workspace-local groups. 

An initial issue I had got resolved quickly by a colleague at databricks. https://dbt-labs.slack.com/archives/C01N1PC89PZ/p1675439047762439?thread_ts=1675422660.545869&cid=C01N1PC89PZ

Unfortunately, a pure `grants` config does not do the trick.

> To perform an action on a schema object, a user must have the USAGE privilege on that schema in addition to the privilege to perform that action.

Thats why we also add a on-run-start operation

